### PR TITLE
Don't double decref resource if pending upload

### DIFF
--- a/managedstorage.go
+++ b/managedstorage.go
@@ -177,7 +177,7 @@ func (ms *managedStorage) getResource(resourceId string, path string) (io.ReadCl
 
 // cleanupResourceCatalog is used to delete a resource catalog record if a put operation fails.
 func cleanupResourceCatalog(rc ResourceCatalog, id string, err *error) {
-	if *err == nil {
+	if *err == nil || errors.Cause(*err) == ErrUploadPending {
 		return
 	}
 	logger.Warningf("cleaning up resource catalog after failed put")


### PR DESCRIPTION
There is a problem with PutForEnvironment where
it will remove a resource if it the upload is
pending in another client. We now don't decrement
the refcount if the upload is pending, as we
already cancel out the initial increment with
the existing resource ID check/removal.

We should allow multiple clients to attempt to
upload concurrently, and choose the winner, as
suggested in #3. This is not handled here.
