### PR TITLE
Fixed outdated import

### DIFF
--- a/gridfs_test.go
+++ b/gridfs_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/blobstore"
 )

--- a/managedstorage_test.go
+++ b/managedstorage_test.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/blobstore"
 )

--- a/resourcecatalog_test.go
+++ b/resourcecatalog_test.go
@@ -11,7 +11,7 @@ import (
 	txntesting "github.com/juju/txn/testing"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/blobstore"
 )


### PR DESCRIPTION
This PR changes the import of gocheck from launchpad to github.
