### PR TITLE
revert PR #22

### DIFF
--- a/managedstorage_test.go
+++ b/managedstorage_test.go
@@ -517,7 +517,6 @@ func (s *managedStorageSuite) checkPutResponse(c *gc.C, index int, wg *sync.Wait
 			c.Check(err, gc.IsNil)
 			if err == nil {
 				r, length, err := s.managedStorage.GetForEnvironment("env", fmt.Sprintf("path/to/blob%d", index))
-				defer r.Close()
 				c.Check(err, gc.IsNil)
 				if err == nil {
 					data, err := ioutil.ReadAll(r)


### PR DESCRIPTION
It is not a good idea to copy the mongo session indiscriminately
because then the view onto the blobstore may be inconsistent
between operations. So we revert the PR #22 which added
session copying and leave it up to the blobstore client
to be responsible for managing the mgo session by calling
Session.Refresh when appropriate.


(Review request: http://reviews.vapour.ws/r/1917/)