### PR TITLE
Special-case length < 0 in PutForEnvironment

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -61,10 +61,18 @@ type ManagedStorage interface {
 	GetForEnvironment(envUUID, path string) (r io.ReadCloser, length int64, err error)
 
 	// PutForEnvironment stores data from reader at path, namespaced to the environment.
+	//
+	// PutForEnvironment is equivalent to PutForEnvironmentAndCheckHash with an empty
+	// hash string.
 	PutForEnvironment(envUUID, path string, r io.Reader, length int64) error
 
 	// PutForEnvironmentAndCheckHash is the same as PutForEnvironment
-	// except that it also checks that the content matches the provided hash.
+	// except that it also checks that the content matches the provided
+	// hash. The hash must be hex-encoded SHA-384.
+	//
+	// If checkHash is empty, then the hash check is elided.
+	//
+	// If length is < 0, then the reader will be consumed until EOF.
 	PutForEnvironmentAndCheckHash(envUUID, path string, r io.Reader, length int64, checkHash string) error
 
 	// RemoveForEnvironment deletes data at path, namespaced to the environment.


### PR DESCRIPTION
If the length passed to PutForEnvironment is < 0, then we just read the entire contents and record the number of bytes read. Also, if the length specified is greater than the amount of data available, then the length recorded in metadata is capped at the actual length.

These changes make it possible to stream to PutForEnvironment without knowing the length ahead of time.

(Review request: http://reviews.vapour.ws/r/2272/)